### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
      - -out
      - /tmp/conf/nginx.crt
     volumes:
-     - ./conf/tls/:/tmp/conf
+     - ./conf/tls/:/tmp/conf:z
 
   bot_app:
     image: cfmanteiga/alpine-bash-curl-jq


### PR DESCRIPTION
Adding SELinux flag so that the mounted volumes can be read from containers. This was preventing openssl container from accessing tls.conf

# podman logs openssl
Can't open "/tmp/conf/tls.conf" for reading, Permission denied 40F77022F47F0000:error:8000000D:system library:BIO_new_file:Permission denied:../crypto/bio/bss_file.c:67:calling fopen(/tmp/conf/tls.conf, r) 40F77022F47F0000:error:10080002:BIO routines:BIO_new_file:system lib:../crypto/bio/bss_file.c:77: